### PR TITLE
Preview mode changes the API endpoint

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -397,8 +397,13 @@ function createUUID() {
 }
 
 const eventData = getAllEventData();
+const containerVersion = getContainerVersion();
+const isPreview = containerVersion.previewMode;
 
-const postUrl = 'https://tr.snapchat.com/v2/conversion';
+let postUrl = 'https://tr.snapchat.com/v2/conversion';
+if(isPreview){
+  postUrl = postUrl + '/validate';
+}
 
 function getCookie1() {
   const existingCookie1 = getCookieValues('_scid')[0];


### PR DESCRIPTION
As specified in that (documentation)[https://businesshelp.snapchat.com/s/article/capi-event-testing?language=en_US], the endpoint is else when you want to validate the test events. That commit changes the endpoint automatically when the preview mode is activated.